### PR TITLE
Took error into account on superagent tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -36,7 +36,7 @@ describe('CSRF', function () {
 			.expect(200)
 			.end(function (err, res) {
 				expect(res.body.token).to.have.length.above(0);
-				done();
+				done(err);
 			});
 	});
 
@@ -58,7 +58,7 @@ describe('CSRF', function () {
 			.post('/csrf')
 			.expect(403)
 			.end(function (err, res) {
-				done();
+				done(err);
 			});
 	});
 });


### PR DESCRIPTION
We were using `superagent` incorrectly.

Since we did not pass along the errors in the `end()` function, it would always continue to the next test as if it had been successful.

This could have caused false positives / negatives.
