### PR TITLE
Correcting header value and implementation of report-uri

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -24,7 +24,7 @@ module.exports = function (options) {
     }
 
     if (reportUri) {
-        value += 'reportUri ' + reportUri;
+        value += 'report-uri ' + reportUri;
     }
 
     return function csp(req, res, next) {

--- a/test/csp.js
+++ b/test/csp.js
@@ -25,7 +25,7 @@ describe('CSP', function () {
 
         request(app)
             .get('/')
-            .expect('Content-Security-Policy-Report-Only', 'default-src *; reportUri ' + config.reportUri)
+            .expect('Content-Security-Policy-Report-Only', 'default-src *; report-uri ' + config.reportUri)
             .expect(200, done);
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -28,7 +28,7 @@ describe('All', function () {
 			.expect('X-FRAME-OPTIONS', config.xframe)
 			.expect('P3P', config.p3p)
 			.expect('Strict-Transport-Security', 'max-age=' + config.hsts.maxAge)
-			.expect('Content-Security-Policy-Report-Only', 'default-src *; reportUri ' + config.csp.reportUri)
+			.expect('Content-Security-Policy-Report-Only', 'default-src *; report-uri ' + config.csp.reportUri)
             .expect('X-XSS-Protection', '1; mode=block')
             .expect(200, done);
 	});


### PR DESCRIPTION
Report-uri was inconsistent with the header values specified by CSP documentation:
https://developer.mozilla.org/en-US/docs/Security/CSP/CSP_policy_directives#report-uri

It should post a header value of report-uri rather than reportUri

Also the option was mismatching latest Kraken docs under middleware: 

```
report-uri - URI the browser should send the report to.
```
