### PR TITLE
Added option of verifying csrf token through custom http header

### DIFF
--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -10,14 +10,16 @@ var token = require('./token');
  * @param {Object} options
  *    key {String} The name of the CSRF token in the model. Default "_csrf".
  *    impl {Object} An object with create/validate methods for custom tokens. Optional.
+ *    header {String} The name of the response header containing the CSRF token. Default "x-csrf-token".
  */
 module.exports = function (options) {
-    var impl, key;
+    var impl, key, header;
 
     options = options || {};
 
     key = options.key || '_csrf';
     impl = options.impl || token;
+    header = options.header || 'x-csrf-token';
 
     return function csrf(req, res, next) {
         var method, token;
@@ -33,7 +35,7 @@ module.exports = function (options) {
         }
 
         // Validate token
-        token = req.body[key];
+        token = req.body[key] || req.headers[header];
 
         if (impl.validate(req, token)) {
             next();

--- a/test/csrf.js
+++ b/test/csrf.js
@@ -32,7 +32,7 @@ describe('CSRF', function () {
     });
 
 
-	it('POST (200 OK with token)', function (done) {
+    it('POST (200 OK with token)', function (done) {
         var app = mock({ csrf: true });
 
         app.all('/', function (req, res) {
@@ -40,17 +40,17 @@ describe('CSRF', function () {
         });
 
         request(app)
-			.get('/')
-			.end(function (err, res) {
-				request(app)
-					.post('/')
+            .get('/')
+            .end(function (err, res) {
+                request(app)
+                    .post('/')
                     .set('cookie', res.headers['set-cookie'])
-					.send({
+                    .send({
                         _csrf: res.body.token
                     })
-					.expect(200, done);
-			});
-	});
+                    .expect(200, done);
+            });
+    });
 
 
     it('POST (403 Forbidden on no token)', function (done) {
@@ -84,6 +84,48 @@ describe('CSRF', function () {
                     .set('cookie', res.headers['set-cookie'])
                     .send({
                         foobar: res.body.token
+                    })
+                    .expect(200, done);
+            });
+    });
+
+    it('Token can be sent through header instead of post body', function (done) {
+        var app = mock({ csrf: true });
+
+        app.all('/', function (req, res) {
+            res.send(200, {token: res.locals._csrf });
+        });
+
+        request(app)
+            .get('/')
+            .end(function (err, res) {
+                request(app)
+                    .post('/')
+                    .set('cookie', res.headers['set-cookie'])
+                    .set('x-csrf-token', res.body.token)
+                    .send({
+                        name: 'Test'
+                    })
+                    .expect(200, done);
+            });
+    });
+
+    it('Should allow custom headers', function (done) {
+        var app = mock({ csrf: {header: 'x-xsrf-token'} });
+
+        app.all('/', function (req, res) {
+            res.send(200, {token: res.locals._csrf });
+        });
+
+        request(app)
+            .get('/')
+            .end(function (err, res) {
+                request(app)
+                    .post('/')
+                    .set('cookie', res.headers['set-cookie'])
+                    .set('x-xsrf-token', res.body.token)
+                    .send({
+                        name: 'Test'
                     })
                     .expect(200, done);
             });


### PR DESCRIPTION
Changes a couple of things in CSRF:
- Allows to send csrf tokens as http header
- Allows for customisation of csrf http header
- Added test cases for both new functionalities
