### PR TITLE
Support using lusca.csrf() without a body

### DIFF
--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -39,7 +39,7 @@ module.exports = function (options) {
         }
 
         // Validate token
-        _token = req.body[key] || req.headers[header];
+        _token = (req.body && req.body[key]) || req.headers[header];
 
         if (validate(req, _token)) {
             next();


### PR DESCRIPTION
Since it is possible to possible to pass the CSRF token as a header, lusca could work even without a body parser (or before the body parser in the middleware stack).