### PR TITLE
classifying no csrf token as separate error than csrf mismatch

### DIFF
--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -23,7 +23,7 @@ module.exports = function (options) {
     secret = options.secret || '_csrfSecret';
 
     return function csrf(req, res, next) {
-        var method, validate, _impl, _token;
+        var method, validate, _impl, _token, errmsg;
 
         //call impl
         _impl = impl.create(req, secret);
@@ -31,7 +31,7 @@ module.exports = function (options) {
         _token = _impl.token || _impl;
         // Set the token
         res.locals[key] = _token;
-        
+
         // Move along for safe verbs
         method = req.method;
         if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
@@ -45,7 +45,13 @@ module.exports = function (options) {
             next();
         } else {
             res.statusCode = 403;
-            next(new Error('CSRF token mismatch'));
+            if (!_token) {
+                errmsg = 'CSRF token missing';
+            } else {
+                errmsg = 'CSRF token mismatch';
+            }
+            next(new Error(errmsg));
         }
+
     };
 };

--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -52,6 +52,5 @@ module.exports = function (options) {
             }
             next(new Error(errmsg));
         }
-
     };
 };

--- a/test/csrf.js
+++ b/test/csrf.js
@@ -98,6 +98,38 @@ describe('CSRF', function () {
                 });
         });
 
+        it('POST (403 Forbidden on invalid token) (session type: {value})', function (ctx, done) {
+            var mockConfig = (ctx.value === 'cookie') ? {
+                    csrf: {
+                        secret: 'csrfSecret'
+                    }
+                } : {
+                    csrf: true
+                },
+                app = mock(mockConfig, ctx.value);
+
+            app.all('/', function (req, res) {
+                res.status(200).send({
+                    token: Math.random()
+                });
+            });
+
+            request(app)
+                .get('/')
+                .end(function (err, res) {
+                    request(app)
+                        .post('/')
+                        .set('Cookie', mapCookies(res.headers['set-cookie']))
+                        .send({
+                            _csrf: res.body.token
+                        })
+                        .expect(403)
+                        .end(function (err, res) {
+                            done(err);
+                        });
+                });
+        });
+
 
         it('POST (403 Forbidden on no token) (session type: {value})', function (ctx, done) {
             var mockConfig = (ctx.value === 'cookie') ? {


### PR DESCRIPTION
Right now, there is no way to identify if the request has no csrf token or bad csrf token. This PR is to address the same and get more visibility around csrf errors.