### PR TITLE
 Updated HSTS to support the preload flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ app.use(lusca({
     csp: { /* ... */},
     xframe: 'SAMEORIGIN',
     p3p: 'ABCDEF',
-    hsts: {maxAge: 31536000, includeSubDomains: true},
+    hsts: {maxAge: 31536000, includeSubDomains: true, preload: true},
     xssProtection: true
 }));
 ```
@@ -104,9 +104,9 @@ Enables [Platform for Privacy Preferences Project](http://support.microsoft.com/
 
 * `options.maxAge` Number - Required. Number of seconds HSTS is in effect.
 * `options.includeSubDomains` Boolean - Optional. Applies HSTS to all subdomains of the host
+* `options.preload` Boolean - Optional. Adds preload flag
 
-Enables [HTTP Strict Transport Security](https://www.owasp.org/index.php/HTTP_Strict_Transport_Security) for the host domain.
-
+Enables [HTTP Strict Transport Security](https://www.owasp.org/index.php/HTTP_Strict_Transport_Security) for the host domain. The preload flag is required for HSTS domain submissions to [Chrome's HSTS preload list](https://hstspreload.appspot.com).
 
 
 ### lusca.xssProtection(options)

--- a/lib/hsts.js
+++ b/lib/hsts.js
@@ -6,21 +6,22 @@
  * https://www.owasp.org/index.php/HTTP_Strict_Transport_Security
  * @param {Object} options
  *     maxAge {Number} The max age of the header. Required.
- *     includeSubDomains {Boolean} 
+ *     includeSubDomains {Boolean}
  */
-module.exports = function (options) {
+module.exports = function(options) {
     var value;
 
     options = options || {};
 
     value = (options.maxAge !== undefined) ? 'max-age=' + options.maxAge : '';
     value += (value && options.includeSubDomains) ? '; includeSubDomains' : '';
+    value += (value && options.preload) ? '; preload' : '';
 
     return function hsts(req, res, next) {
         if (value) {
             res.header('Strict-Transport-Security', value);
         }
-        
+
         next();
     };
 };

--- a/lib/hsts.js
+++ b/lib/hsts.js
@@ -8,7 +8,7 @@
  *     maxAge {Number} The max age of the header. Required.
  *     includeSubDomains {Boolean}
  */
-module.exports = function(options) {
+module.exports = function (options) {
     var value;
 
     options = options || {};

--- a/test/hsts.js
+++ b/test/hsts.js
@@ -60,6 +60,26 @@ describe('HSTS', function () {
     });
 
 
+    it('header (maxAge; includeSubDomains; preload)', function (done) {
+        var config = { hsts: { maxAge: 31536000, includeSubDomains: true, preload: true} },
+            app = mock(config);
+
+        app.get('/', function (req, res) {
+            res.status(200).end();
+        });
+
+        request(app)
+            .get('/')
+            .expect(
+                'Strict-Transport-Security',
+                'max-age=' + config.hsts.maxAge +
+                '; includeSubDomains' +
+                '; preload'
+            )
+            .expect(200, done);
+    });
+
+
     it('header (missing maxAge)', function (done) {
         var config = { hsts: {} },
             app = mock(config);


### PR DESCRIPTION
Hey, I've updated the HSTS implementation to support the preload flag. This flag is required for HSTS domain submissions to Chrome's preload list. The changes include new feature support, new test case, and updated docs. More information regarding preload is available below

https://hstspreload.appspot.com/