### PR TITLE
add cookie setting and angular shorthand option to csrf

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ __Please note that you must use [express-session](https://github.com/expressjs/s
 * `key` String - Optional. The name of the CSRF token added to the model. Defaults to `_csrf`.
 * `secret` String - Optional. The key to place on the session object which maps to the server side token. Defaults to `_csrfSecret`.
 * `impl` Function - Optional. Custom implementation to generate a token.
+* `cookie` String - Optional. If set, a cookie with the name you provide will be set with the CSRF token.
+* `angular` Boolean - Optional. Shorthand setting to set `lusca` up to use the default settings for CSRF validation according to the [AngularJS docs].
+
+[angularjs docs]: https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection
 
 Enables [Cross Site Request Forgery](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_\(CSRF\)) (CSRF) headers.
 

--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -13,14 +13,21 @@ var token = require('./token');
  *    header {String} The name of the response header containing the CSRF token. Default "x-csrf-token".
  */
 module.exports = function (options) {
-    var impl, key, header, secret;
+    var impl, key, header, secret, cookie;
 
     options = options || {};
+
+    if (options.angular) {
+        options.header = 'X-XSRF-TOKEN';
+        options.cookie = 'XSRF-TOKEN';
+    }
 
     key = options.key || '_csrf';
     impl = options.impl || token;
     header = options.header || 'x-csrf-token';
     secret = options.secret || '_csrfSecret';
+    cookie = options.cookie;
+
 
     return function csrf(req, res, next) {
         var method, validate, _impl, _token, errmsg;
@@ -31,6 +38,9 @@ module.exports = function (options) {
         _token = _impl.token || _impl;
         // Set the token
         res.locals[key] = _token;
+        if (cookie) {
+            res.cookie(cookie, _token);
+        }
 
         // Move along for safe verbs
         method = req.method;

--- a/test/csrf.js
+++ b/test/csrf.js
@@ -342,4 +342,25 @@ describe('CSRF', function () {
                 });
         });
     });
+
+    it('Should set a cookie with the cookie option', function (done) {
+        var app = mock({ csrf: { cookie: 'CSRF' }});
+
+        app.all('/', function (req, res) {
+            res.status(200).send({
+                token: res.locals._csrf
+            });
+        });
+
+        request(app)
+            .get('/')
+            .end(function (err, res) {
+                function findToken(cookie) {
+                    cookie = decodeURIComponent(cookie);
+                    return ~cookie.indexOf(res.body.token);
+                }
+                assert(res.headers['set-cookie'].some(findToken));
+                done();
+            });
+    });
 });

--- a/test/csrf.js
+++ b/test/csrf.js
@@ -363,4 +363,35 @@ describe('CSRF', function () {
                 done();
             });
     });
+    it('Should set options correctly with an angular shorthand option', function (done) {
+        // https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection
+        var cookieKey = 'XSRF-TOKEN';
+        var header = 'X-XSRF-TOKEN';
+        var app = mock({ csrf: { angular: true, secret: '_csrfSecret' }});
+
+        app.all('/', function (req, res) {
+            res.status(200).send({
+                token: res.locals._csrf
+            });
+        });
+
+        request(app)
+            .get('/')
+            .end(function (err, res) {
+                function findToken(cookie) {
+                    cookie = decodeURIComponent(cookie);
+                    return ~cookie.indexOf(cookieKey + '=' + res.body.token);
+                }
+                assert(res.headers['set-cookie'].some(findToken));
+
+                request(app)
+                    .post('/')
+                    .set('cookie', mapCookies(res.headers['set-cookie']))
+                    .set(header, res.body.token)
+                    .send({
+                        cool: 'stuff'
+                    })
+                    .expect(200, done);
+            });
+    });
 });


### PR DESCRIPTION
This change introduces two new features to csrf:
1. `cookie` option which, when configured, sets a cookie with the csrf token
2. `angular` option which, when true, sets the options based on the defaults defined in angular's [$http]

[$http]: https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection