### PR TITLE
Add bypass csrf validation for post first applications

### DIFF
--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -48,6 +48,11 @@ module.exports = function (options) {
             return next();
         }
 
+        // bypass validation for applications with initial request of POST
+        if (req.lusca && req.lusca.bypassCSRFCheck) {
+            return next();
+        }
+
         // Validate token
         _token = (req.body && req.body[key]) || req.headers[header.toLowerCase()];
 


### PR DESCRIPTION
Certain applications (e.g. merchant integration) may have an initial request of POST. If this occurs, we need to bypass the csrf validation, but still generate a token for future requests.

Setting this bypass flag will require some simple no-op middleware on a per route basis.