### PR TITLE
add req.csrfToken back in

### DIFF
--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -28,19 +28,45 @@ module.exports = function (options) {
     secret = options.secret || '_csrfSecret';
     cookie = options.cookie;
 
+    function getCsrf(req, secret) {
+        var _impl, validate, _token, _secret;
 
-    return function csrf(req, res, next) {
-        var method, validate, _impl, _token, errmsg;
-
-        //call impl
         _impl = impl.create(req, secret);
         validate = impl.validate || _impl.validate;
         _token = _impl.token || _impl;
-        // Set the token
-        res.locals[key] = _token;
+        _secret = _impl.secret;
+
+        return {
+            validate: validate,
+            token: _token,
+            secret: _secret
+        };
+    }
+
+    function setToken(res, token) {
+        res.locals[key] = token;
         if (cookie) {
-            res.cookie(cookie, _token);
+            res.cookie(cookie, token);
         }
+    }
+
+
+    return function checkCsrf(req, res, next) {
+        var method, _token, errmsg;
+
+        var csrf = getCsrf(req, secret);
+        setToken(res, csrf.token);
+
+        req.csrfToken = function csrfToken() {
+            var newCsrf = getCsrf(req, secret);
+            if (csrf.secret && newCsrf.secret && csrf.secret === newCsrf.secret) {
+                return csrf.token;
+            }
+
+            csrf = newCsrf;
+            setToken(res, csrf.token);
+            return csrf.token;
+        };
 
         // Move along for safe verbs
         method = req.method;
@@ -51,7 +77,7 @@ module.exports = function (options) {
         // Validate token
         _token = (req.body && req.body[key]) || req.headers[header.toLowerCase()];
 
-        if (validate(req, _token)) {
+        if (csrf.validate(req, _token)) {
             next();
         } else {
             res.statusCode = 403;

--- a/lib/token.js
+++ b/lib/token.js
@@ -20,6 +20,7 @@ function create(req, secretKey) {
     }
 
     return {
+        secret: secret,
         token: tokenize(salt(LENGTH), secret),
         validate: function validate(req, token) {
             if (typeof token !== 'string') {


### PR DESCRIPTION
#### minor release

this method is added to enable the session handler to retrigger csrf seeding / token generation as necessary.

I'd prefer to have late generation but that's a bigger change and I'd like to get this out.