### PR TITLE
feat(CSP): Added optional custom impl function that creates a report-uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ __Please note that you must use [express-session](https://github.com/expressjs/s
 
 ### lusca.csrf(options)
 
-* `key` String - Optional. The name of the CSRF token added to the model. Defaults to `_csrf`.
-* `secret` String - Optional. The key to place on the session object which maps to the server side token. Defaults to `_csrfSecret`.
-* `impl` Function - Optional. Custom implementation to generate a token.
-* `cookie` String - Optional. If set, a cookie with the name you provide will be set with the CSRF token.
-* `angular` Boolean - Optional. Shorthand setting to set `lusca` up to use the default settings for CSRF validation according to the [AngularJS docs].
+* `options.key` String - Optional. The name of the CSRF token added to the model. Defaults to `_csrf`.
+* `options.secret` String - Optional. The key to place on the session object which maps to the server side token. Defaults to `_csrfSecret`.
+* `options.impl` Function - Optional. Custom implementation to generate a token.
+* `options.cookie` String - Optional. If set, a cookie with the name you provide will be set with the CSRF token.
+* `options.angular` Boolean - Optional. Shorthand setting to set `lusca` up to use the default settings for CSRF validation according to the [AngularJS docs].
 
 [angularjs docs]: https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection
 
@@ -71,6 +71,7 @@ If enabled, the CSRF token must be in the payload when modifying data or you wil
 * `options.policy` Object - Object definition of policy.
 * `options.reportOnly` Boolean - Enable report only mode.
 * `options.reportUri` String - URI where to send the report data
+* `options.impl` Function - Custom implementation to create a report-uri (higher priority than `options.reportUri`)
 
 Enables [Content Security Policy](https://www.owasp.org/index.php/Content_Security_Policy) (CSP) headers.
 

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -10,6 +10,7 @@ module.exports = function (options) {
     var policyRules = options && options.policy,
         isReportOnly = options && options.reportOnly,
         reportUri = options && options.reportUri,
+        reportUriImpl = options && options.impl,
         value = '',
         name, key;
 
@@ -23,11 +24,14 @@ module.exports = function (options) {
         value += key + ' ' + policyRules[key] + '; ';
     }
 
-    if (reportUri) {
-        value += 'report-uri ' + reportUri;
-    }
-
     return function csp(req, res, next) {
+
+        if (reportUriImpl) {
+            value += 'report-uri ' + reportUriImpl(req);
+        } else if (reportUri) {
+            value += 'report-uri ' + reportUri;
+        }
+
         res.header(name, value);
         next();
     };

--- a/test/csp.js
+++ b/test/csp.js
@@ -30,6 +30,21 @@ describe('CSP', function () {
     });
 
 
+    it('header (report) - allows custom report-uri impl function', function (done) {
+        var config = require('./mocks/config/cspReportUriImpl'),
+            app = mock({ csp: config });
+
+        app.get('/', function (req, res) {
+            res.status(200).end();
+        });
+
+        request(app)
+            .get('/')
+            .expect('Content-Security-Policy-Report-Only', 'default-src *; report-uri http://www.example.com?token=sometoken')
+            .expect(200, done);
+    });
+
+
     it('header (enforce)', function (done) {
         var config = require('./mocks/config/cspEnforce'),
             app = mock({ csp: config });

--- a/test/mocks/config/cspReportUriImpl.js
+++ b/test/mocks/config/cspReportUriImpl.js
@@ -1,0 +1,12 @@
+'use strict';
+
+
+module.exports = {
+	reportOnly: true,
+	impl: function (req) {
+		return 'http://www.example.com?token=sometoken';
+	},
+	policy: {
+		"default-src": "*"
+	}
+};


### PR DESCRIPTION
- Added optional custom `impl` function that creates a report-uri.  Used if you want to tack on a token or some unique identifier to the end of the report-uri to help identify a user or session (for logging, analytics, etc.)
- Added a unit test

![img](https://assets-animated.rbl.ms/2219766/980x.gif)

/cc @jasisk 
