### PR TITLE
Add support for arrays in CSP

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -23,7 +23,7 @@ module.exports = function (options) {
     for (key in policyRules) {
 
         var rule = policyRules[key];
-        if (rule && rule.constructor === Array) {
+        if (Array.isArray(rule)) {
             rule = rule.join(" ");
         }
         values.push(key + ' ' + rule + '; ');

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -19,9 +19,16 @@ module.exports = function (options) {
         name += '-Report-Only';
     }
 
+    var values = [];
     for (key in policyRules) {
-        value += key + ' ' + policyRules[key] + '; ';
+
+        var rule = policyRules[key];
+        if (rule && rule.constructor === Array) {
+            rule = rule.join(" ");
+        }
+        values.push(key + ' ' + rule + '; ');
     }
+    value = values.join('');
 
     if (reportUri) {
         value += 'report-uri ' + reportUri;

--- a/test/csp.js
+++ b/test/csp.js
@@ -44,4 +44,18 @@ describe('CSP', function () {
             .expect(200, done);
     });
 
+    it('header (array)', function (done) {
+        var config = require('./mocks/config/cspArray'),
+            app = mock({ csp: config });
+
+        app.get('/', function (req, res) {
+            res.status(200).end();
+        });
+
+        request(app)
+            .get('/')
+            .expect('Content-Security-Policy', 'default-src * blob: data:; ')
+            .expect(200, done);
+    });
+
 });

--- a/test/mocks/config/cspArray.js
+++ b/test/mocks/config/cspArray.js
@@ -1,0 +1,9 @@
+'use strict';
+
+
+module.exports = {
+	reportOnly: false,
+	policy: {
+		"default-src": ["*", "blob:", "data:"]
+	}
+};


### PR DESCRIPTION
Configuring CSP in lusca makes the config file look unreadable.
Oftentimes, you'll have more than 2-3 entries in `default-src` or `img-src`, and these can be quite long.

This PR offers the users a chance to specify entries in the policy with an array, which will allow them to break it into lines, and make the config files much more readable and debuggable.

Compare

``` json
"policy": {
    "default-src": "'self' https://*.google-analytics.com https://*.mydomain.com https://*.mydomain2.com  http://*.mydomain2.com ",
    "script-src": "'self' https://*.google-analytics.com https://*.mydomain.com https://*.mydomain2.com ",
}
```

to

``` json
"policy": {
    "default-src": ["'self'", 
                "https://*.google-analytics.com",
                "https://*.mydomain.com",
                "https://*.mydomain2.com",
                "http://*.mydomain2.com"],

    "script-src": ["'self'",
               "https://*.google-analytics.com",
               "https://*.mydomain.com",
               "https://*.mydomain2.com"]
}
```

For backwards compatability, the ability to specify it as a string like before was retained.
