### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Enables [Cross Site Request Forgery](https://www.owasp.org/index.php/Cross-Site_
 
 If enabled, the CSRF token must be in the payload when modifying data or you will receive a *403 Forbidden*. To send the token you'll need to echo back the `_csrf` value you received from the previous request.
 
+URL-encoded body parsers, such as [body-parser](https://github.com/expressjs/body-parser), must be used to read CSRF tokens via form data. Furthermore, body parsers must be instantiated before lusca.
 
 ### lusca.csp(options)
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Enables [Cross Site Request Forgery](https://www.owasp.org/index.php/Cross-Site_
 
 If enabled, the CSRF token must be in the payload when modifying data or you will receive a *403 Forbidden*. To send the token you'll need to echo back the `_csrf` value you received from the previous request.
 
-URL-encoded body parsers, such as [body-parser](https://github.com/expressjs/body-parser), must be used to read CSRF tokens via form data. Furthermore, body parsers must be instantiated before lusca.
+Furthermore, parsers must be registered before lusca. 
 
 ### lusca.csp(options)
 


### PR DESCRIPTION
I spent a good while trying to get CSRF protection working on my server, and it turned out that the reason it wasn't was because I had enabled body parser **after** lusca! Switching the order promptly fixed my issue.
