### PR TITLE
Handle request cookie in order to get csrf token.

### DIFF
--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -75,7 +75,7 @@ module.exports = function (options) {
         }
 
         // Validate token
-        _token = (req.body && req.body[key]) || req.headers[header.toLowerCase()];
+        _token = (req.body && req.body[key]) || req.headers[header.toLowerCase()] || req.cookies[cookie];
 
         if (csrf.validate(req, _token)) {
             next();


### PR DESCRIPTION
If there is no security reason for taking csrf token in request cookie I think we can handle it that way.

The benefit of this approach is that when your set `credentials: 'same-origin'` (or equivalent for whatever http client you use, I am using aurelia-fetch-client) by default the client send cookie with requests. If not we have to write http interceptor in order to add this header.

See: [Requests with credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Requests_with_credentials)