### PR TITLE
Change csp api to handle more directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,10 @@ If enabled, the CSRF token must be in the payload when modifying data or you wil
 
 ### lusca.csp(options)
 
-* `options.policy` Object - Object definition of policy.
+* `options.policy` String, Object, or an Array - Object definition of policy. Valid policies examples include:
+  * `{"default-src": "*"}`
+  * `"referrer no-referrer"`
+  * `[{ "img-src": "'self' http:" }, "block-all-mixed-content"]`
 * `options.reportOnly` Boolean - Enable report only mode.
 * `options.reportUri` String - URI where to send the report data
 

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var thing = require('core-util-is');
+
 
 /**
  * Content Security Policy (CSP)
@@ -10,8 +12,7 @@ module.exports = function (options) {
     var policyRules = options && options.policy,
         isReportOnly = options && options.reportOnly,
         reportUri = options && options.reportUri,
-        value = '',
-        name, key;
+        value, name;
 
     name = 'Content-Security-Policy';
 
@@ -19,11 +20,12 @@ module.exports = function (options) {
         name += '-Report-Only';
     }
 
-    for (key in policyRules) {
-        value += key + ' ' + policyRules[key] + '; ';
-    }
+    value = createPolicyString(policyRules);
 
     if (reportUri) {
+        if (value !== '') {
+            value += '; ';
+        }
         value += 'report-uri ' + reportUri;
     }
 
@@ -31,4 +33,29 @@ module.exports = function (options) {
         res.header(name, value);
         next();
     };
+};
+
+var createPolicyString = module.exports.createPolicyString = function (policy) {
+    var entries;
+
+    if (thing.isString(policy)) {
+        return policy;
+    }
+
+    if (thing.isArray(policy)) {
+        return policy.map(createPolicyString).join('; ');
+    }
+
+    if (thing.isObject(policy)) {
+        entries = Object.keys(policy).map(function (directive) {
+            if (policy[directive] === 0 || policy[directive]) {
+                directive += ' ' + policy[directive];
+            }
+            return directive;
+        });
+
+        return createPolicyString(entries);
+    }
+
+    throw Error('invalid csp policy - must be array, string, or plain object');
 };

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "grunt-mocha-test": "~0.7.0",
     "jshint": "*",
     "supertest": "^0.13.0"
+  },
+  "dependencies": {
+    "core-util-is": "^1.0.2"
   }
 }

--- a/test/csp.js
+++ b/test/csp.js
@@ -15,6 +15,13 @@ describe('CSP', function () {
     });
 
 
+    it('should throw if misconfigured', function () {
+        assert.throws(function () {
+            lusca.csp(new Date());
+        }, /invalid csp policy/);
+    });
+
+
     it('header (report)', function (done) {
         var config = require('./mocks/config/cspReport'),
             app = mock({ csp: config });
@@ -30,18 +37,61 @@ describe('CSP', function () {
     });
 
 
-    it('header (enforce)', function (done) {
-        var config = require('./mocks/config/cspEnforce'),
+    describe('header (enforce)', function () {
+        it('object config', function (done) {
+            var config = require('./mocks/config/cspEnforce'),
             app = mock({ csp: config });
 
-        app.get('/', function (req, res) {
-            res.status(200).end();
+            app.get('/', function (req, res) {
+                res.status(200).end();
+            });
+
+            request(app)
+                .get('/')
+                .expect('Content-Security-Policy', 'default-src *')
+                .expect(200, done);
         });
 
-        request(app)
-            .get('/')
-            .expect('Content-Security-Policy', 'default-src *; ')
-            .expect(200, done);
-    });
+        it('string config', function (done) {
+            var config = require('./mocks/config/cspString'),
+            app = mock({ csp: config });
 
+            app.get('/', function (req, res) {
+                res.status(200).end();
+            });
+
+            request(app)
+                .get('/')
+                .expect('Content-Security-Policy', 'default-src *')
+                .expect(200, done);
+        });
+
+        it('array config', function (done) {
+            var config = require('./mocks/config/cspArray'),
+            app = mock({ csp: config });
+
+            app.get('/', function (req, res) {
+                res.status(200).end();
+            });
+
+            request(app)
+                .get('/')
+                .expect('Content-Security-Policy', 'default-src *; img-src *')
+                .expect(200, done);
+        });
+
+        it('nested config', function (done) {
+            var config = require('./mocks/config/cspNested'),
+            app = mock({ csp: config });
+
+            app.get('/', function (req, res) {
+                res.status(200).end();
+            });
+
+            request(app)
+                .get('/')
+                .expect('Content-Security-Policy', 'default-src *; img-src *')
+                .expect(200, done);
+        });
+    });
 });

--- a/test/mocks/config/cspArray.json
+++ b/test/mocks/config/cspArray.json
@@ -1,0 +1,3 @@
+{
+  "policy": ["default-src *", "img-src *"]
+}

--- a/test/mocks/config/cspNested.json
+++ b/test/mocks/config/cspNested.json
@@ -1,0 +1,6 @@
+{
+  "policy": [
+    {"default-src": "*"},
+    "img-src *"
+  ]
+}

--- a/test/mocks/config/cspString.json
+++ b/test/mocks/config/cspString.json
@@ -1,0 +1,1 @@
+{ "policy": "default-src *" }


### PR DESCRIPTION
This change is long overdue and has had a couple attempts by others (sorry, folks!).

Implemented a more flexible, yet backwards-compatible csp api. Csp policies are more fluid than our current api supports with things like argument-less directives (e.g., `block-all-mixed-content`).

New api supports string policies for maximum flexibility, array policies (just fancy string concatenation), and the old object policy api.

Big thanks to @turboMaCk and @giladgo for their PRs ages ago. I've thrown commits from you two into this PR to ensure they're at least captured in the repo.

Closes #69, #71, #72.

**edit** does introduce a behavior change but only the case of a failed policy. Previously would either result in a context-less throw or fail silently. Now, an unhanded policy type throws explicitly.