### PR TITLE
Put in return to suppress promise warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ var lusca = module.exports = function (options) {
                         return;
                     }
                     header(req, res, next);
+                    return;
                 };
             }(chain));
         });


### PR DESCRIPTION
This prevents this warning with node 7.7.4...
Warning: a promise was created in a handler at Users/nates/Documents/Development/shy/node_modules/lusca/index.js:48:21 but was not returned from it, see http://goo.gl/rRqMUw

Solves [issue 101](https://github.com/krakenjs/lusca/issues/101).