### PR TITLE
Allow CSRF cookie options to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ __Please note that you must use [express-session](https://github.com/expressjs/s
 * `key` String - Optional. The name of the CSRF token added to the model. Defaults to `_csrf`.
 * `secret` String - Optional. The key to place on the session object which maps to the server side token. Defaults to `_csrfSecret`.
 * `impl` Function - Optional. Custom implementation to generate a token.
-* `cookie` String - Optional. If set, a cookie with the name you provide will be set with the CSRF token.
-* `angular` Boolean - Optional. Shorthand setting to set `lusca` up to use the default settings for CSRF validation according to the [AngularJS docs].
+* `cookie` String|Object - Optional. If set, a cookie with the name and/or options you provide will be set with the CSRF token. If the value is a string, it'll be used as the cookie name.
+* `cookie.name` String - Required if cookie is an object and `angular` is not true. The CSRF cookie name to set.
+* `cookie.options` Object - Optional. A valid Express cookie options object.
+* `angular` Boolean - Optional. Shorthand setting to set `lusca` up to use the default settings for CSRF validation according to the [AngularJS docs]. Can be used with `cookie.options`.
 
 [angularjs docs]: https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection
 

--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -19,14 +19,30 @@ module.exports = function (options) {
 
     if (options.angular) {
         options.header = 'X-XSRF-TOKEN';
-        options.cookie = 'XSRF-TOKEN';
+        options.cookie = {
+            name: 'XSRF-TOKEN'            
+        };
     }
 
     key = options.key || '_csrf';
     impl = options.impl || token;
     header = options.header || 'x-csrf-token';
     secret = options.secret || '_csrfSecret';
-    cookie = options.cookie;
+    
+    // Check if cookie is string or object
+    if (typeof options.cookie === 'string') {
+        cookie = {
+            name: options.cookie,
+        };
+    } else {
+        cookie = {
+            name: options.cookie.name
+        };
+    }
+    
+    // Set cookie options
+    cookie.options = options.cookie && options.cookie.options ?
+        options.cookie.options : {};
 
     function getCsrf(req, secret) {
         var _impl, validate, _token, _secret;
@@ -45,8 +61,9 @@ module.exports = function (options) {
 
     function setToken(res, token) {
         res.locals[key] = token;
+        
         if (cookie) {
-            res.cookie(cookie, token);
+            res.cookie(cookie.name, token, cookie.options);
         }
     }
 
@@ -55,6 +72,7 @@ module.exports = function (options) {
         var method, _token, errmsg;
 
         var csrf = getCsrf(req, secret);
+        
         setToken(res, csrf.token);
 
         req.csrfToken = function csrfToken() {
@@ -70,6 +88,7 @@ module.exports = function (options) {
 
         // Move along for safe verbs
         method = req.method;
+        
         if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
             return next();
         }
@@ -81,11 +100,13 @@ module.exports = function (options) {
             next();
         } else {
             res.statusCode = 403;
+            
             if (!_token) {
                 errmsg = 'CSRF token missing';
             } else {
                 errmsg = 'CSRF token mismatch';
             }
+            
             next(new Error(errmsg));
         }
     };

--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -21,7 +21,7 @@ module.exports = function (options) {
         options.header = 'X-XSRF-TOKEN';
         options.cookie = {
             name: 'XSRF-TOKEN',
-            options: options.cookie.options
+            options: options.cookie && options.cookie.options
         };
     }
 
@@ -29,7 +29,7 @@ module.exports = function (options) {
     impl = options.impl || token;
     header = options.header || 'x-csrf-token';
     secret = options.secret || '_csrfSecret';
-    
+
     // Check if cookie is string or object
     if (typeof options.cookie === 'string') {
         cookie = {
@@ -40,10 +40,9 @@ module.exports = function (options) {
             name: options.cookie.name
         };
     }
-    
+
     // Set cookie options
-    cookie.options = options.cookie && options.cookie.options ?
-        options.cookie.options : {};
+    cookie.options = options.cookie && options.cookie.options || {};
 
     function getCsrf(req, secret) {
         var _impl, validate, _token, _secret;
@@ -62,7 +61,7 @@ module.exports = function (options) {
 
     function setToken(res, token) {
         res.locals[key] = token;
-        
+
         if (cookie) {
             res.cookie(cookie.name, token, cookie.options);
         }
@@ -73,7 +72,7 @@ module.exports = function (options) {
         var method, _token, errmsg;
 
         var csrf = getCsrf(req, secret);
-        
+
         setToken(res, csrf.token);
 
         req.csrfToken = function csrfToken() {
@@ -89,7 +88,7 @@ module.exports = function (options) {
 
         // Move along for safe verbs
         method = req.method;
-        
+
         if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
             return next();
         }
@@ -101,13 +100,13 @@ module.exports = function (options) {
             next();
         } else {
             res.statusCode = 403;
-            
+
             if (!_token) {
                 errmsg = 'CSRF token missing';
             } else {
                 errmsg = 'CSRF token mismatch';
             }
-            
+
             next(new Error(errmsg));
         }
     };

--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -20,7 +20,8 @@ module.exports = function (options) {
     if (options.angular) {
         options.header = 'X-XSRF-TOKEN';
         options.cookie = {
-            name: 'XSRF-TOKEN'            
+            name: 'XSRF-TOKEN',
+            options: options.cookie.options
         };
     }
 

--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -37,7 +37,7 @@ module.exports = function (options) {
         };
     } else {
         cookie = {
-            name: options.cookie.name
+            name: options.cookie && options.cookie.name
         };
     }
 


### PR DESCRIPTION
This fix allows us to set cookie options and maintain compatibility with current configurations.

Example configurations:
```js
// Using AngularJS with cookie options
lusca.csrf({
  angular: true,
  cookie: {
    options: {
      httpOnly: true,
      secure: true
    }
  }
});
```

```js
// Using custom cookie name and options.
lusca.csrf({
  cookie: {
    name: 'MyCustomCSRFCookieName',
    options: {
      httpOnly: true,
      secure: true
    }
  }
});
```

```js
// Using this also works
lusca.csrf({
  cookie: 'MyCustomCSRFCookieName'
});
```

```js
// Using this works too
lusca.csrf({
  cookie: {
    name: 'MyCustomCSRFCookieName'
  }
});
```