### PR TITLE
Add style/script directive if nonce is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##### v1.5.2
+
+* Bugfix: Add style/script directive if nonce is true
+
 ##### v1.5.1
 
 * Bugfix: style-src nonce updates properly, speed improvement on match

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -19,7 +19,7 @@ module.exports = function (options) {
         name += '-report-only';
     }
 
-    if (policyRules["default-src"]) {
+    if (policyRules && policyRules["default-src"]) {
         if (styleNonce && !policyRules["style-src"]) {
             policyRules["style-src"] = policyRules["default-src"];
         }

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -19,6 +19,9 @@ module.exports = function (options) {
         name += '-report-only';
     }
 
+    policyRules["style-src"] = policyRules["style-src"] || styleNonce ? policyRules["default-src"] : undefined;
+    policyRules["script-src"] = policyRules["script-src"] || scriptNonce ?  policyRules["default-src"] : undefined;
+
     value = createPolicyString(policyRules);
 
     if (reportUri) {

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -19,12 +19,12 @@ module.exports = function (options) {
         name += '-report-only';
     }
 
-    if(policyRules["default-src"]) {
-        if(styleNonce && !policyRules["style-src"]) {
+    if (policyRules["default-src"]) {
+        if (styleNonce && !policyRules["style-src"]) {
             policyRules["style-src"] = policyRules["default-src"];
         }
         
-        if(scriptNonce && !policyRules["script-src"]) {
+        if (scriptNonce && !policyRules["script-src"]) {
             policyRules["script-src"] = policyRules["default-src"];
         }
     }

--- a/lib/csp.js
+++ b/lib/csp.js
@@ -19,8 +19,15 @@ module.exports = function (options) {
         name += '-report-only';
     }
 
-    policyRules["style-src"] = policyRules["style-src"] || styleNonce ? policyRules["default-src"] : undefined;
-    policyRules["script-src"] = policyRules["script-src"] || scriptNonce ?  policyRules["default-src"] : undefined;
+    if(policyRules["default-src"]) {
+        if(styleNonce && !policyRules["style-src"]) {
+            policyRules["style-src"] = policyRules["default-src"];
+        }
+        
+        if(scriptNonce && !policyRules["script-src"]) {
+            policyRules["script-src"] = policyRules["default-src"];
+        }
+    }
 
     value = createPolicyString(policyRules);
 


### PR DESCRIPTION
If app is using default-src for fall back for script-src/style-src, then nonce won't get enforced in header even if scriptNonce/styleNonce is true as these directives are no available in csp policy.