### PR TITLE
Allows CSRF whitelist and blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ __Please note that you must use [express-session](https://github.com/expressjs/s
 * `cookie.name` String - Required if cookie is an object and `angular` is not true. The CSRF cookie name to set.
 * `cookie.options` Object - Optional. A valid Express cookie options object.
 * `angular` Boolean - Optional. Shorthand setting to set `lusca` up to use the default settings for CSRF validation according to the [AngularJS docs]. Can be used with `cookie.options`.
+* `blacklist` Array or String - Optional. Allows defining a set of routes that will not have csrf protection.  All others will.
+* `whitelist` Array or String - Optional. Allows defining a set of routes that will have csrf protection.  All others will not.
 
 [angularjs docs]: https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ __Please note that you must use [express-session](https://github.com/expressjs/s
 * `blacklist` Array or String - Optional. Allows defining a set of routes that will not have csrf protection.  All others will.
 * `whitelist` Array or String - Optional. Allows defining a set of routes that will have csrf protection.  All others will not.
 
-Note: The app should use either a `blacklist` or a `whitelist`, not both.
+Notes: The app can use either a `blacklist` or a `whitelist`, not both.  By default, all post routes are whitelisted.
 
 [angularjs docs]: https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ __Please note that you must use [express-session](https://github.com/expressjs/s
 * `blacklist` Array or String - Optional. Allows defining a set of routes that will not have csrf protection.  All others will.
 * `whitelist` Array or String - Optional. Allows defining a set of routes that will have csrf protection.  All others will not.
 
+Note: The app should use either a `blacklist` or a `whitelist`, not both.
+
 [angularjs docs]: https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection
 
 Enables [Cross Site Request Forgery](https://www.owasp.org/index.php/Cross-Site_Request_Forgery_\(CSRF\)) (CSRF) headers.

--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -14,7 +14,7 @@ var token = require('./token'),
  *    header {String} The name of the response header containing the CSRF token. Default "x-csrf-token".
  */
 module.exports = function (options) {
-    var impl, key, header, secret, cookie;
+    var impl, key, header, secret, cookie, whitelist, blacklist;
 
     options = options || {};
 
@@ -24,6 +24,24 @@ module.exports = function (options) {
             name: 'XSRF-TOKEN',
             options: options.cookie && options.cookie.options
         };
+    }
+
+    whitelist = options.whitelist;
+
+    if (typeof whitelist === 'string') {
+        whitelist = [ whitelist ];
+    } else if (!Array.isArray(whitelist)) {
+        // Don't allow non string or array whitelist
+        whitelist = null;
+    }
+
+    blacklist = options.blacklist;
+
+    if (typeof blacklist === 'string') {
+        blacklist = [ blacklist ];
+    } else if (!Array.isArray(blacklist)) {
+        // Don't allow non string or array blacklist
+        blacklist = null;
     }
 
     key = options.key || '_csrf';
@@ -70,6 +88,25 @@ module.exports = function (options) {
 
 
     return function checkCsrf(req, res, next) {
+
+        var shouldBypass = false;
+
+        if (blacklist) {
+            blacklist.some(function (exclusion) {
+                shouldBypass = req.path.indexOf(exclusion) === 0;
+            });
+        }
+
+        if (whitelist) {
+            whitelist.some(function (inclusion) {
+                shouldBypass = req.path.indexOf(inclusion) !== 0;
+            });
+        }
+
+        if (shouldBypass) {
+            return next();
+        }
+
         var method, _token, errmsg;
 
         var csrf = getCsrf(req, secret);

--- a/test/csrf.js
+++ b/test/csrf.js
@@ -42,6 +42,60 @@ describe('CSRF', function () {
                 done(err);
             });
     });
+    it('should not require token on post to blacklist', function (done) {
+        var app = mock({
+            csrf: {
+                blacklist: ['/blacklist']
+            }
+        });
+
+        app.post('/blacklist', function (req, res) {
+            res.send(200);
+        });
+
+        app.post('/notblacklist', function (req, res) {
+            res.send(200);
+        });
+
+        request(app)
+            .post('/blacklist')
+            .expect(200)
+            .end(function (err, res) {});
+
+        request(app)
+            .post('/notblacklist')
+            .expect(403)
+            .end(function (err, res) {
+                done(err);
+            });
+    });
+    it('should only require token on post to whitelist', function (done) {
+        var app = mock({
+            csrf: {
+                whitelist: ['/whitelist']
+            }
+        });
+
+        app.post('/whitelist', function (req, res) {
+            res.send(200);
+        });
+
+        app.post('/notwhitelist', function (req, res) {
+            res.send(200);
+        });
+
+        request(app)
+            .post('/whitelist')
+            .expect(403)
+            .end(function (err, res) {});
+
+        request(app)
+            .post('/notwhitelist')
+            .expect(200)
+            .end(function (err, res) {
+                done(err);
+            });
+    });
     dd(sessionOptions, function () {
         it('GETs have a CSRF token (session type: {value})', function (ctx, done) {
             var mockConfig = (ctx.value === 'cookie') ? {


### PR DESCRIPTION
Enables defining an array or string of routes that either require a CSRF token for only those routes or do not require of CSRF token for only those routes.

eg: 
```
csrf: {
  'whitelist': [ '/whitelist', '/also/whitelist' ]
}
```

If you try to reach either `/whitelist` or `/also/whitelist`, you will need a CSRF token but all other post routes will not require one.  

If you configured that as blacklist, those routes would not require a CSRF token but all others would.