### PR TITLE
fix blacklist or whitelist judge error

### DIFF
--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -92,14 +92,14 @@ module.exports = function (options) {
         var shouldBypass = false;
 
         if (blacklist) {
-            blacklist.some(function (exclusion) {
-                shouldBypass = req.path.indexOf(exclusion) === 0;
+            shouldBypass = blacklist.some(function (exclusion) {
+                return req.path.indexOf(exclusion) === 0;
             });
         }
 
         if (whitelist) {
-            whitelist.some(function (inclusion) {
-                shouldBypass = req.path.indexOf(inclusion) !== 0;
+            shouldBypass = whitelist.some(function (inclusion) {
+                return req.path.indexOf(inclusion) !== 0;
             });
         }
 


### PR DESCRIPTION
when my blacklist is [ '/a', '/b ] and my request is '/a',
the blacklist is not working

in csrf.js file
```
if (blacklist) {
    blacklist.some(function (exclusion) {
        shouldBypass = req.path.indexOf(exclusion) === 0;
    });
}

if (whitelist) {
    whitelist.some(function (inclusion) {
        shouldBypass = req.path.indexOf(inclusion) !== 0;
    });
}
```
i think `Array.some()` use error
And should like this
```
if (blacklist) {
  shouldBypass = blacklist.some(function (exclusion) {
      return req.path.indexOf(exclusion) === 0;
  });
}

if (whitelist) {
  shouldBypass = whitelist.some(function (inclusion) {
      return req.path.indexOf(inclusion) !== 0;
  });
}
```
And then passed！！
