### PR TITLE
Disable x-xss-protection by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Enables [HTTP Strict Transport Security](https://www.owasp.org/index.php/HTTP_St
 
 ### lusca.xssProtection(options)
 
-* `options.enabled` Boolean - Optional. If the header is enabled or not (see header docs). Defaults to `1`.
-* `options.mode` String - Optional. Mode to set on the header (see header docs). Defaults to `block`.
+* `options.enabled` Boolean - Optional. If the header is enabled or not (see header docs). Defaults to `0`.
+* `options.mode` String - Optional. Mode to set on the header (see header docs). Defaults to ``.
 
 Enables [X-XSS-Protection](http://blogs.msdn.com/b/ie/archive/2008/07/02/ie8-security-part-iv-the-xss-filter.aspx) headers to help prevent cross site scripting (XSS) attacks in older IE browsers (IE8)
 

--- a/lib/xssprotection.js
+++ b/lib/xssprotection.js
@@ -8,11 +8,16 @@ module.exports = function xssProtection(options) {
     options = options || {};
 
     // `enabled` should be either `1` or `0`
-    var enabled = (options.enabled !== undefined) ? +options.enabled : 1;
-    var mode = options.mode || 'block';
+    var enabled = (options.enabled !== undefined) ? +options.enabled : 0;
+    var mode = options.mode || '';
 
     return function xssProtection(req, res, next) {
-        res.header('x-xss-protection', enabled + '; mode=' + mode);
+        if (!mode) {
+            res.header('x-xss-protection', enabled);
+        } else {
+            res.header('x-xss-protection', enabled + '; mode=' + mode);
+        }
+        
         next();
     };
 };


### PR DESCRIPTION
As you know, Google Chrome Developers disabled XSS Auditor. Developers should be able to disable the auditor for older browsers and set it to 0.
The `x-xss-protection` header was found to have a multitude of issues, instead of helping the developers protect their application. (e.g. Bypass `x-xss-protection` header)

The following discussion describes the issue at hand with more references: 

https://github.com/OWASP/CheatSheetSeries/issues/376
https://github.com/OWASP/CheatSheetSeries/pull/378

Available for further discussions 😄 