### PR TITLE
fix :bug: allowlist.type exact

### DIFF
--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -116,7 +116,7 @@ module.exports = function (options) {
         }
 
         if (allowlist) {
-            shouldBypass = !allowlistExact.has(req.path) ||
+            shouldBypass = allowlistExact.has(req.path) ||
                 allowlistStartsWith.some(function (inclusion) {
                 shouldBypass = req.path.indexOf(inclusion) !== 0;
                 return shouldBypass;


### PR DESCRIPTION
```json
"csrf": {
  "allowlist": [
    { "path": "/webhook", "type": "exact" }
  ]
},
```