### PR TITLE
set csrf token on response for bypassed POST urls

### DIFF
--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -123,10 +123,6 @@ module.exports = function (options) {
             });
         }
 
-        if (shouldBypass) {
-            return next();
-        }
-
         var method, _token, errmsg;
 
         var csrf = getCsrf(req, secret);
@@ -148,7 +144,10 @@ module.exports = function (options) {
         // Move along for safe verbs
         method = req.method;
 
-        if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
+        if (// Move along if POST URL is added for bypass
+            (method === 'POST' && shouldBypass) ||
+            // Move along for safe verbs
+            method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
             return next();
         }
 

--- a/test/csrf.js
+++ b/test/csrf.js
@@ -114,6 +114,27 @@ describe('CSRF', function () {
                 done(err);
             });
     });
+    it('should set token on response on post to blocklist (string config)', function (done) {
+        var app = mock({
+            csrf: {
+                blocklist: '/blocklist1'
+            }
+        });
+
+        app.post('/blocklist1', function (req, res) {
+            res.status(200).send({
+                token: res.locals._csrf
+            });
+        });
+
+        request(app)
+            .post('/blocklist1')
+            .expect(200)
+            .end(function (err, res) {
+                assert(res.body.token);
+                done(err);
+            });
+    });
     it('should only require token on post to allowlist', function (done) {
         var app = mock({
             csrf: {


### PR DESCRIPTION
When a URL is added to be bypassed, CSRF is not set in the response which leads to subsequent POST requests throwing a 403. 
This change sets the CSRF token in `res.locals` before bypassing the validation.

Fixes - https://github.com/krakenjs/lusca/issues/142